### PR TITLE
Add profile support for different environments

### DIFF
--- a/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/ActiveProfilesVerifier.java
+++ b/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/ActiveProfilesVerifier.java
@@ -1,0 +1,59 @@
+package uk.gov.crowncommercial.esourcing.integration.app;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+
+public class ActiveProfilesVerifier {
+
+  private static final Set<String> ENVIRONMENT_PROFILES = Collections.unmodifiableSet(
+      new HashSet<String>(Arrays.asList("local", "dev", "sandbox", "test", "uat")));
+
+  private final boolean enabled;
+
+  @Value("${spring.profiles.active:}")
+  private Set<String> activeProfiles;
+
+
+  public ActiveProfilesVerifier() {
+    this(true);
+  }
+
+  public ActiveProfilesVerifier(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  /**
+   * Check the "environment" profiles against a defined set and ensure one and only one is defined.
+   * 
+   * @param activeProfiles the active profiles defined
+   * @throws IllegalStateException if 0 or >1 are defined
+   */
+  public void verify() throws IllegalStateException {
+    if (enabled) {
+      doVerify(activeProfiles);
+    }
+  }
+
+  public static void doVerify(Set<String> activeProfiles) throws IllegalStateException {
+
+    Set<String> intersect = new HashSet<>(ENVIRONMENT_PROFILES);
+    intersect.retainAll(activeProfiles);
+
+    if (intersect.size() == 0) {
+      // no environmental profile set - we need one
+      throw new IllegalStateException(
+          "No environment profile has been defined. Set spring.profiles.active to one of "
+              + String.join(",", ENVIRONMENT_PROFILES));
+    } else if (intersect.size() == 1) {
+      // just one - this is what we want
+    } else {
+      // more than one environmental profile set - we need just one
+      throw new IllegalStateException("Multiple environment profiles has been defined "
+          + String.join(",", intersect) + ". Set spring.profiles.active to only one of "
+          + String.join(",", ENVIRONMENT_PROFILES));
+    }
+  }
+}

--- a/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/AppConfiguration.java
+++ b/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/AppConfiguration.java
@@ -12,4 +12,19 @@ public class AppConfiguration {
     /* create a Clock so time can easily be overridden/mocked when unit testing */
     return Clock.systemUTC();
   }
+
+  @Bean
+  InfoAppConfigurationProperties infoAppConfigurationProperties() {
+    return new InfoAppConfigurationProperties();
+  }
+  
+  @Bean
+  ApplicationStartupCompleteListener applicationStartupCompleteListener() {
+    return new ApplicationStartupCompleteListener();
+  }
+  
+  @Bean
+  ActiveProfilesVerifier activeProfilesVerifier() {
+    return new ActiveProfilesVerifier(true);
+  }
 }

--- a/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/ApplicationStartupCompleteListener.java
+++ b/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/ApplicationStartupCompleteListener.java
@@ -1,0 +1,18 @@
+package uk.gov.crowncommercial.esourcing.integration.app;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+public class ApplicationStartupCompleteListener
+    implements ApplicationListener<ContextRefreshedEvent> {
+
+  @Autowired
+  private ActiveProfilesVerifier activeProfilesVerifier;
+
+  @Override
+  public void onApplicationEvent(ContextRefreshedEvent event) {
+    
+    activeProfilesVerifier.verify();
+  }
+}

--- a/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/InfoAppConfigurationProperties.java
+++ b/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/InfoAppConfigurationProperties.java
@@ -1,0 +1,27 @@
+package uk.gov.crowncommercial.esourcing.integration.app;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "info.app")
+public final class InfoAppConfigurationProperties {
+
+  private String name;
+
+  private String version;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+}

--- a/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/RollbarConfig.java
+++ b/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/RollbarConfig.java
@@ -1,7 +1,7 @@
 package uk.gov.crowncommercial.esourcing.integration.app;
 
 import java.util.function.Supplier;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -17,55 +17,40 @@ import com.rollbar.spring.webmvc.RollbarSpringConfigBuilder;
 @ComponentScan({"com.rollbar.spring"})
 public class RollbarConfig {
 
-  @Value("${rollbar.enabled:false}")
-  private boolean enabled;
+  @Autowired
+  InfoAppConfigurationProperties infoAppCfgProps;
 
-  @Value("${rollbar.accesstoken:#{null}}")
-  private String accessToken;
-
-  @Value("${rollbar.environment:#{null}}")
-  private String environment;
-
-  @Value("${rollbar.framework:#{null}}")
-  private String framework;
-
-  @Value("${rollbar.endpoint:#{null}}")
-  private String endpoint;
-
-  @Value("${info.app.name:#{null}}")
-  private String infoAppName;
-
-  @Value("${info.app.version:#{null}}")
-  private String infoAppVersion;
+  @Bean
+  RollbarConfigurationProperties rollbarConfigurationProperties() {
+    return new RollbarConfigurationProperties();
+  }
 
   @Bean
   public Rollbar rollbar(Supplier<Sender> senderSupplier) {
 
-    ConfigBuilder builder = RollbarSpringConfigBuilder.withAccessToken(accessToken).enabled(enabled)
-        .sender(senderSupplier.get());
+    RollbarConfigurationProperties cfgProps = rollbarConfigurationProperties();
 
-    if (accessToken != null) {
-      builder.accessToken(accessToken);
+    ConfigBuilder builder = RollbarSpringConfigBuilder.withAccessToken(cfgProps.getAccessToken())
+        .enabled(cfgProps.isEnabled()).sender(senderSupplier.get());
+
+    if (cfgProps.getEndpoint() != null) {
+      builder.endpoint(cfgProps.getEndpoint());
     }
 
-    if (endpoint != null) {
-      builder.endpoint(endpoint);
-    }
-
-    if (environment != null) {
-      builder.environment(environment);
+    if (cfgProps.getEnvironment() != null) {
+      builder.environment(cfgProps.getEnvironment());
     }
 
     /* framework defaults to app name (if set) or the framework value if set */
-    if (infoAppName != null) {
-      builder.framework(infoAppName);
+    if (infoAppCfgProps.getName() != null) {
+      builder.framework(infoAppCfgProps.getName());
     }
-    if (framework != null) {
-      builder.framework(framework);
+    if (cfgProps.getFramework() != null) {
+      builder.framework(cfgProps.getFramework());
     }
 
-    if (infoAppVersion != null) {
-      builder.codeVersion(infoAppVersion);
+    if (infoAppCfgProps.getVersion() != null) {
+      builder.codeVersion(infoAppCfgProps.getVersion());
     }
 
     return new Rollbar(builder.build());

--- a/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/RollbarConfigurationProperties.java
+++ b/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/app/RollbarConfigurationProperties.java
@@ -1,0 +1,58 @@
+package uk.gov.crowncommercial.esourcing.integration.app;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "rollbar")
+public final class RollbarConfigurationProperties {
+
+  private boolean enabled;
+
+  private String accessToken;
+
+  private String environment;
+
+  private String framework;
+
+  private String endpoint;
+  
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public String getEnvironment() {
+    return environment;
+  }
+
+  public String getFramework() {
+    return framework;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  public void setEnvironment(String environment) {
+    this.environment = environment;
+  }
+
+  public void setFramework(String framework) {
+    this.framework = framework;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+}

--- a/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/auth/AuthConfiguration.java
+++ b/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/auth/AuthConfiguration.java
@@ -15,13 +15,13 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
 @EnableWebSecurity
 public class AuthConfiguration extends WebSecurityConfigurerAdapter {
 
-  @Value("${ccs.esourcing.tenders.apikeyheader:x-api-key}")
+  @Value("${ccs.esourcing.tenders.api-key-header:x-api-key}")
   private String apiKeyHeader;
   
-  @Value("${ccs.esourcing.tenders.apikeys:}")
+  @Value("${ccs.esourcing.tenders.api-keys:}")
   private Set<String> apiKeys;
   
-  @Value("${ccs.esourcing.tenders.ipallowlist:}")
+  @Value("${ccs.esourcing.tenders.ipallow-list:}")
   private Set<String> ipAllowList;
 
   @Override

--- a/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/service/TenderApiService.java
+++ b/integration-app/src/main/java/uk/gov/crowncommercial/esourcing/integration/service/TenderApiService.java
@@ -24,7 +24,7 @@ public class TenderApiService implements TendersApiDelegate {
 
   private static final Logger logger = LoggerFactory.getLogger(TenderApiService.class);
 
-  @Value("${ccs.esourcing.tenders.jaggaerclienturl}")
+  @Value("${ccs.esourcing.tenders.jaggaer-client-url}")
   private String JAGGAER_CLIENT_URL;
 
   public TenderApiService() {

--- a/integration-app/src/main/resources/application-dev.properties
+++ b/integration-app/src/main/resources/application-dev.properties
@@ -1,0 +1,19 @@
+# ===================================================================
+# DEVELOPMENT PROFILE SPRING BOOT PROPERTIES
+#
+# This file contains application properties used for the development
+# environment.
+#
+# See https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+#
+# ===================================================================
+
+# ----------------------------------------
+# CCS ESOURCING PROPERTIES
+# ----------------------------------------
+
+
+# ----------------------------------------
+# ROLLBAR PROPERTIES
+# ----------------------------------------
+rollbar.environment=dev

--- a/integration-app/src/main/resources/application-local.properties
+++ b/integration-app/src/main/resources/application-local.properties
@@ -1,9 +1,8 @@
 # ===================================================================
-# DEVELOPMENT SPRING BOOT PROPERTIES
+# LOCAL PROFILE SPRING BOOT PROPERTIES
 #
-# This file contains application properties that will be picked up
-# during development in the IDE but will not make it into the
-# war/jar file.
+# This file contains application properties used during local
+# application development.
 #
 # See https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
 #
@@ -25,5 +24,16 @@ logging.level.uk.gov.crowncommercial.esourcing=TRACE
 # CCS ESOURCING PROPERTIES
 # ----------------------------------------
 
-ccs.esourcing.tenders.ipallowlist=127.0.0.1, 0:0:0:0:0:0:0:1
-ccs.esourcing.tenders.apikeys=84b0d964-6047-428c-a41f-7df98ccdc6b6
+ccs.esourcing.tenders.ip-allow-list=127.0.0.1, 0:0:0:0:0:0:0:1
+ccs.esourcing.tenders.api-keys=84b0d964-6047-428c-a41f-7df98ccdc6b6
+
+# ----------------------------------------
+# JAGGAER CLIENT API PROPERTIES
+# ----------------------------------------
+
+ccs.esourcing.tenders.jaggaer-client-url=http://localhost:8081/joeraymond-roweit/Tenders/1.0.0/
+
+# ----------------------------------------
+# ROLLBAR PROPERTIES
+# ----------------------------------------
+rollbar.environment=local

--- a/integration-app/src/main/resources/application-sandbox.properties
+++ b/integration-app/src/main/resources/application-sandbox.properties
@@ -1,0 +1,19 @@
+# ===================================================================
+# SANDBOX PROFILE SPRING BOOT PROPERTIES
+#
+# This file contains application properties used for the development
+# environment.
+#
+# See https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+#
+# ===================================================================
+
+# ----------------------------------------
+# CCS ESOURCING PROPERTIES
+# ----------------------------------------
+
+
+# ----------------------------------------
+# ROLLBAR PROPERTIES
+# ----------------------------------------
+rollbar.environment=sandbox

--- a/integration-app/src/main/resources/application-test.properties
+++ b/integration-app/src/main/resources/application-test.properties
@@ -1,0 +1,19 @@
+# ===================================================================
+# TEST PROFILE SPRING BOOT PROPERTIES
+#
+# This file contains application properties used for the test
+# environment.
+#
+# See https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+#
+# ===================================================================
+
+# ----------------------------------------
+# CCS ESOURCING PROPERTIES
+# ----------------------------------------
+
+
+# ----------------------------------------
+# ROLLBAR PROPERTIES
+# ----------------------------------------
+rollbar.environment=test

--- a/integration-app/src/main/resources/application-uat.properties
+++ b/integration-app/src/main/resources/application-uat.properties
@@ -1,0 +1,19 @@
+# ===================================================================
+# UAT PROFILE SPRING BOOT PROPERTIES
+#
+# This file contains application properties used for the UAT
+# environment.
+#
+# See https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+#
+# ===================================================================
+
+# ----------------------------------------
+# CCS ESOURCING PROPERTIES
+# ----------------------------------------
+
+
+# ----------------------------------------
+# ROLLBAR PROPERTIES
+# ----------------------------------------
+rollbar.environment=uat

--- a/integration-app/src/main/resources/application.properties
+++ b/integration-app/src/main/resources/application.properties
@@ -36,23 +36,22 @@ management.endpoints.web.exposure.include=health,info,prometheus,metrics
 # CCS ESOURCING PROPERTIES
 # ----------------------------------------
 
-# ccs.esourcing.tenders.ipallowlist= # comma separated list of ipv4 addresses from which requests are allowed from, empty list then no filtering
-# ccs.esourcing.tenders.apikeyheader= # HTTP header to be used for API Key authentication
-# ccs.esourcing.tenders.apikeys= # comma separated list of API keys used for "authenticating" requests
+# ccs.esourcing.tenders.ipallow-list= # comma separated list of ipv4 addresses from which requests are allowed from, empty list then no filtering
+# ccs.esourcing.tenders.api-key-header= # HTTP header to be used for API Key authentication
+# ccs.esourcing.tenders.api-keys= # comma separated list of API keys used for "authenticating" requests
 
 # ----------------------------------------
 # JAGGAER CLIENT API PROPERTIES
 # ----------------------------------------
 
-# TODO - shouldn't be any dev specifics in here as this gets built into the deployed jar
-ccs.esourcing.tenders.jaggaerclienturl=http://localhost:8081/joeraymond-roweit/Tenders/1.0.0/
+# ccs.esourcing.tenders.jaggaer-client-url= # URL for the Jaggaer endpoint
 
 # ----------------------------------------
 # ROLLBAR PROPERTIES
 # ----------------------------------------
 
 # rollbar.enabled= # true|false to enable/disable rollbar functionality
-# rollbar.accesstoken= # access token used by rollbar to send
+# rollbar.access-token= # access token used by rollbar to send
 # rollbar.environment= # environment field value 
 # rollbar.framework= # framework field value
 # rollbar.endpoint= # rollbar endpoint in case this needs to be overridden 

--- a/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/ApiExceptionHandlerRollbarDisabledIT.java
+++ b/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/ApiExceptionHandlerRollbarDisabledIT.java
@@ -53,11 +53,11 @@ public class ApiExceptionHandlerRollbarDisabledIT {
   
   @DynamicPropertySource
   public static void setDynamicProperties(DynamicPropertyRegistry registry) {
-    registry.add("ccs.esourcing.tenders.ipallowlist", () -> "127.0.0.1");
-    registry.add("ccs.esourcing.tenders.apikeys", () -> "banana");
+    registry.add("ccs.esourcing.tenders.ip-allow-list", () -> "127.0.0.1");
+    registry.add("ccs.esourcing.tenders.api-keys", () -> "integration-test-api-key");
     registry.add("rollbar.enabled", () -> "false");
   }
-
+  
   @Test
   public void getTenderById_throwsNullPointerException_expectInternalServerErrorAndRollbarSend()
       throws Exception {
@@ -69,7 +69,7 @@ public class ApiExceptionHandlerRollbarDisabledIT {
     /* "call" the REST API */
     MvcResult mvcResult = mockMvc
         .perform(MockMvcRequestBuilders.get(CCS_API_BASE_PATH + "/tenders/1")
-            .header(API_KEY_HEADER, "banana").contentType(MediaType.APPLICATION_JSON))
+            .header(API_KEY_HEADER, "integration-test-api-key").contentType(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isInternalServerError()).andReturn();
 
     /* verify the REST API response */

--- a/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/ApiExceptionHandlerRollbarEnabledIT.java
+++ b/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/ApiExceptionHandlerRollbarEnabledIT.java
@@ -57,10 +57,10 @@ public class ApiExceptionHandlerRollbarEnabledIT {
 
   @DynamicPropertySource
   public static void setDynamicProperties(DynamicPropertyRegistry registry) {
-    registry.add("ccs.esourcing.tenders.ipallowlist", () -> "127.0.0.1");
-    registry.add("ccs.esourcing.tenders.apikeys", () -> "banana");
+    registry.add("ccs.esourcing.tenders.ip-allow-list", () -> "127.0.0.1");
+    registry.add("ccs.esourcing.tenders.api-keys", () -> "integration-test-api-key");
     registry.add("rollbar.enabled", () -> "true");
-    registry.add("rollbar.accesstoken", () -> "1298350192839123616203759102938");
+    registry.add("rollbar.access-token", () -> "1298350192839123616203759102938");
     registry.add("rollbar.environment", () -> "integration_test");
     registry.add("info.app.version", () -> "12.34.56");
   }
@@ -76,7 +76,7 @@ public class ApiExceptionHandlerRollbarEnabledIT {
     /* "call" the REST API */
     MvcResult mvcResult = mockMvc
         .perform(MockMvcRequestBuilders.get(CCS_API_BASE_PATH + "/tenders/1")
-            .header(API_KEY_HEADER, "banana").contentType(MediaType.APPLICATION_JSON))
+            .header(API_KEY_HEADER, "integration-test-api-key").contentType(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isInternalServerError()).andReturn();
 
     /* verify the REST API response */
@@ -102,7 +102,7 @@ public class ApiExceptionHandlerRollbarEnabledIT {
   public void getNoSuchFile_withApiKey_expectNotFoundAndNoRollbarSend() throws Exception {
 
     MvcResult mvcResult = mockMvc.perform(
-        MockMvcRequestBuilders.get("/nosuchfile.txt").header(Constants.API_KEY_HEADER, "banana"))
+        MockMvcRequestBuilders.get("/nosuchfile.txt").header(Constants.API_KEY_HEADER, "integration-test-api-key"))
         .andExpect(MockMvcResultMatchers.status().isNotFound()).andReturn();
 
     assertThat(mvcResult.getResponse().getContentAsString()).isEmpty();

--- a/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/IntegrationTestConfig.java
+++ b/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/IntegrationTestConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import com.rollbar.notifier.sender.Sender;
+import uk.gov.crowncommercial.esourcing.integration.app.ActiveProfilesVerifier;
 
 @Configuration
 public class IntegrationTestConfig {
@@ -19,14 +20,25 @@ public class IntegrationTestConfig {
   @Bean
   @Primary
   Supplier<Sender> mockSenderSupplier() {
-    /* override the Sender so we can intercept rollbar sends and mock as needed */ 
+    /* override the Sender so we can intercept rollbar sends and mock as needed */
     return () -> mockSender;
   }
 
   @Bean
   @Primary
   Clock fixedClock() {
-    /* for most tests a repeatable / fixed clock is useful, if need anything more may need to mock it */ 
+    /*
+     * for most tests a repeatable / fixed clock is useful, if need anything more may need to mock
+     * it
+     */
     return Clock.fixed(Instant.ofEpochSecond(1610454603L), ZoneId.of("UTC"));
   }
+
+  @Bean
+  @Primary
+  ActiveProfilesVerifier disabledActiveProfilesVerifier() {
+    /* override and disable active profile environment checking */
+    return new ActiveProfilesVerifier(false);
+  }
+
 }

--- a/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/StaticFilesIT.java
+++ b/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/StaticFilesIT.java
@@ -23,8 +23,8 @@ public class StaticFilesIT {
 
   @DynamicPropertySource
   public static void setDynamicProperties(DynamicPropertyRegistry registry) {
-    registry.add("ccs.esourcing.tenders.ipallowlist", () -> "127.0.0.1");
-    registry.add("ccs.esourcing.tenders.apikeys", () -> "banana");
+    registry.add("ccs.esourcing.tenders.ip-allow-list", () -> "127.0.0.1");
+    registry.add("ccs.esourcing.tenders.api-keys", () -> "integration-test-api-key");
   }
 
   @Autowired
@@ -70,7 +70,7 @@ public class StaticFilesIT {
   public void getNoSuchFile_withApiKey_expectNotFound() throws Exception {
 
     MvcResult mvcResult = mockMvc
-        .perform(MockMvcRequestBuilders.get("/nosuchfile.txt").header(Constants.API_KEY_HEADER, "banana"))
+        .perform(MockMvcRequestBuilders.get("/nosuchfile.txt").header(Constants.API_KEY_HEADER, "integration-test-api-key"))
         .andExpect(MockMvcResultMatchers.status().isNotFound()).andReturn();
 
     assertThat(mvcResult.getResponse().getContentAsString()).isEmpty();

--- a/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/StaticFilesIpRestrictedIT.java
+++ b/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/StaticFilesIpRestrictedIT.java
@@ -22,7 +22,7 @@ public class StaticFilesIpRestrictedIT {
 
   @DynamicPropertySource
   public static void setDynamicProperties(DynamicPropertyRegistry registry) {
-    registry.add("ccs.esourcing.tenders.ipallowlist", () -> "123.456.789.123");
+    registry.add("ccs.esourcing.tenders.ip-allow-list", () -> "123.456.789.123");
   }
 
   @Autowired

--- a/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/StaticFilesNoIpRestrictionsIT.java
+++ b/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/StaticFilesNoIpRestrictionsIT.java
@@ -22,7 +22,7 @@ public class StaticFilesNoIpRestrictionsIT {
 
   @DynamicPropertySource
   public static void setDynamicProperties(DynamicPropertyRegistry registry) {
-    registry.add("ccs.esourcing.tenders.ipallowlist", () -> "");
+    registry.add("ccs.esourcing.tenders.ip-allow-list", () -> "");
   }
 
   @Autowired

--- a/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/TendersApiControllerIT.java
+++ b/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/TendersApiControllerIT.java
@@ -45,8 +45,8 @@ public class TendersApiControllerIT {
 
   @DynamicPropertySource
   public static void setDynamicProperties(DynamicPropertyRegistry registry) {
-    registry.add("ccs.esourcing.tenders.ipallowlist", () -> "127.0.0.1");
-    registry.add("ccs.esourcing.tenders.apikeys", () -> "banana");
+    registry.add("ccs.esourcing.tenders.ip-allow-list", () -> "127.0.0.1");
+    registry.add("ccs.esourcing.tenders.api-keys", () -> "integration-test-api-key");
   }
 
   @Test
@@ -58,7 +58,7 @@ public class TendersApiControllerIT {
 
     MvcResult mvcResult = mockMvc
         .perform(MockMvcRequestBuilders.get(CCS_API_BASE_PATH + "/tenders/1")
-            .header(API_KEY_HEADER, "banana").contentType(MediaType.APPLICATION_JSON))
+            .header(API_KEY_HEADER, "integration-test-api-key").contentType(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
     String expected = objectMapper.writeValueAsString(tender);

--- a/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/TendersApiControllerIpRestrictedIT.java
+++ b/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/TendersApiControllerIpRestrictedIT.java
@@ -43,8 +43,8 @@ public class TendersApiControllerIpRestrictedIT {
 
   @DynamicPropertySource
   public static void setDynamicProperties(DynamicPropertyRegistry registry) {
-    registry.add("ccs.esourcing.tenders.ipallowlist", () -> "123.456.789.123");
-    registry.add("ccs.esourcing.tenders.apikeys", () -> "banana");
+    registry.add("ccs.esourcing.tenders.ip-allow-list", () -> "123.456.789.123");
+    registry.add("ccs.esourcing.tenders.api-keys", () -> "integration-test-api-key");
   }
 
   @Test
@@ -56,7 +56,7 @@ public class TendersApiControllerIpRestrictedIT {
 
     MvcResult mvcResult = mockMvc
         .perform(MockMvcRequestBuilders.get(Constants.CCS_API_BASE_PATH + "/tenders/1")
-            .header(Constants.API_KEY_HEADER, "banana").contentType(MediaType.APPLICATION_JSON))
+            .header(Constants.API_KEY_HEADER, "integration-test-api-key").contentType(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isForbidden()).andReturn();
 
     assertThat(mvcResult.getResponse().getContentAsString()).isEmpty();
@@ -82,7 +82,7 @@ public class TendersApiControllerIpRestrictedIT {
 
     MvcResult mvcResult = mockMvc
         .perform(MockMvcRequestBuilders.get(Constants.CCS_API_BASE_PATH + "/tenders/1")
-            .header("X-Forwarded-For", "123.456.789.123").header(Constants.API_KEY_HEADER, "banana")
+            .header("X-Forwarded-For", "123.456.789.123").header(Constants.API_KEY_HEADER, "integration-test-api-key")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
@@ -99,7 +99,7 @@ public class TendersApiControllerIpRestrictedIT {
 
     MvcResult mvcResult = mockMvc
         .perform(MockMvcRequestBuilders.get(Constants.CCS_API_BASE_PATH + "/tenders/1")
-            .header("X-Forwarded-For", "123.456.789.123, 10.0.0.1").header(Constants.API_KEY_HEADER, "banana")
+            .header("X-Forwarded-For", "123.456.789.123, 10.0.0.1").header(Constants.API_KEY_HEADER, "integration-test-api-key")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
@@ -116,7 +116,7 @@ public class TendersApiControllerIpRestrictedIT {
 
     MvcResult mvcResult = mockMvc
         .perform(MockMvcRequestBuilders.get(Constants.CCS_API_BASE_PATH + "/tenders/1")
-            .header("X-Forwarded-For", "111.222.333.444").header(Constants.API_KEY_HEADER, "banana")
+            .header("X-Forwarded-For", "111.222.333.444").header(Constants.API_KEY_HEADER, "integration-test-api-key")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isForbidden()).andReturn();
 
@@ -132,7 +132,7 @@ public class TendersApiControllerIpRestrictedIT {
 
     MvcResult mvcResult = mockMvc
         .perform(MockMvcRequestBuilders.get(Constants.CCS_API_BASE_PATH + "/tenders/1")
-            .header("X-Forwarded-For", "111.222.333.444, 10.0.0.1").header(Constants.API_KEY_HEADER, "banana")
+            .header("X-Forwarded-For", "111.222.333.444, 10.0.0.1").header(Constants.API_KEY_HEADER, "integration-test-api-key")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isForbidden()).andReturn();
 

--- a/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/TendersApiControllerNoIpRestrictionsIT.java
+++ b/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/api/TendersApiControllerNoIpRestrictionsIT.java
@@ -45,8 +45,8 @@ public class TendersApiControllerNoIpRestrictionsIT {
 
   @DynamicPropertySource
   public static void setDynamicProperties(DynamicPropertyRegistry registry) {
-    registry.add("ccs.esourcing.tenders.ipallowlist", () -> "");
-    registry.add("ccs.esourcing.tenders.apikeys", () -> "banana");
+    registry.add("ccs.esourcing.tenders.ip-allow-list", () -> "");
+    registry.add("ccs.esourcing.tenders.api-keys", () -> "integration-test-api-key");
   }
 
   @Test
@@ -58,7 +58,7 @@ public class TendersApiControllerNoIpRestrictionsIT {
 
     MvcResult mvcResult = mockMvc
         .perform(MockMvcRequestBuilders.get(CCS_API_BASE_PATH + "/tenders/1")
-            .header(API_KEY_HEADER, "banana").contentType(MediaType.APPLICATION_JSON))
+            .header(API_KEY_HEADER, "integration-test-api-key").contentType(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
     String expected = objectMapper.writeValueAsString(tender);

--- a/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/app/ActiveProfilesVerifierTest.java
+++ b/integration-app/src/test/java/uk/gov/crowncommercial/esourcing/integration/app/ActiveProfilesVerifierTest.java
@@ -1,0 +1,41 @@
+package uk.gov.crowncommercial.esourcing.integration.app;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.Arrays;
+import java.util.HashSet;
+import org.junit.jupiter.api.Test;
+
+public class ActiveProfilesVerifierTest {
+
+  @Test
+  public void verify_testNoActiveProfiles_expectException() {
+
+    assertThrows(IllegalStateException.class, () -> {
+      ActiveProfilesVerifier.doVerify(new HashSet<>());
+    });
+  }
+
+  @Test
+  public void verify_testNoEnvironmentActiveProfiles_expectException() {
+
+    assertThrows(IllegalStateException.class, () -> {
+      ActiveProfilesVerifier
+          .doVerify(new HashSet<String>(Arrays.asList("default", "postgres", "es7")));
+    });
+  }
+
+  @Test
+  public void verify_testOneEnvironmentActiveProfile_expectOkay() {
+
+    ActiveProfilesVerifier.doVerify(new HashSet<String>(Arrays.asList("dev", "postgres", "es7")));
+  }
+
+  @Test
+  public void verify_testTwoEnvironmentActiveProfiles_expectException() {
+
+    assertThrows(IllegalStateException.class, () -> {
+      ActiveProfilesVerifier
+          .doVerify(new HashSet<String>(Arrays.asList("dev", "uat", "postgres", "es7")));
+    });
+  }
+}


### PR DESCRIPTION
Partly to allow me to test rollbar have moved the local application.properties and renamed as application-local.properties. Also created an application-{env}.properties file for each environment that contains all the necessary properties needed to config that environement. We can only include non secure stuff in here as these are checked in. At the moment only the `rollbar.environment` is set.
Added code to check that the environment profile has been set to one of a set number of values, and that only one is set.
Also changed all properties to use the kebab case format as recommended by Spring so that the _relaxed binding_ works and we can inject using the kebab-case, camelCase or as UPPER_CASE environment variables.
To launch the application will now need to set -Dspring.profiles.active=local for local development, -Dspring.profiles.active=sandbox etc for GOV.UK PaaS deployment.
Rollbar is disabled by default, this can be enabled using properties or environment variables appropriately.